### PR TITLE
Remove tab characters from JSON

### DIFF
--- a/route53_backup.json
+++ b/route53_backup.json
@@ -60,9 +60,9 @@
              "    sts_client = boto3.client('sts')\n",
              
              "    assumedRoleObject = sts_client.assume_role(",
-             { "Fn::Join": ["",["		RoleArn=\"",{"Fn::GetAtt": ["Route53Backup","Arn"] },"\","]]},
-             "    	RoleSessionName=\"Route53Backup\"",
-             "	)\n",
+             { "Fn::Join": ["",["        RoleArn=\"",{"Fn::GetAtt": ["Route53Backup","Arn"] },"\","]]},
+             "      RoleSessionName=\"Route53Backup\"",
+             "  )\n",
  
              "    credentials = assumedRoleObject['Credentials']\n",
  


### PR DESCRIPTION
Removed the embedded tab characters from the file to allow a clean conversion to a YAML template using aws-cfn-template-flip